### PR TITLE
Uppercase letters in sub name would result in 0 Output in output_finetuning_data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cache_dir/*
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.vscode/launch.json

--- a/model_finetuning/output_finetuning_data.py
+++ b/model_finetuning/output_finetuning_data.py
@@ -79,6 +79,7 @@ training_subreddits = []
 if config['DEFAULT']['training_subreddits']:
 	training_subreddits = config['DEFAULT']['training_subreddits'].split(',')
 
+training_subreddits=[x.lower() for x in training_subreddits]
 
 def tag_submission(sub):
 


### PR DESCRIPTION
Having capital letters in the training_subreddits would cause 0 Output, even though they were downloaded and the submission was stored with capital letters in the DB. E.g "RimWorld" would give no output, while "rimworld" would output normally. Making everything in training_subreddit lowercase works around this.